### PR TITLE
Refactor clients and network calls

### DIFF
--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,252 @@
+{
+    "id": "37i9dQZEVXcBWKkqzRzenz",
+    "uri": "spotify:playlist:37i9dQZEVXcBWKkqzRzenz",
+    "name": "Discover Weekly",
+    "description": "Your weekly mixtape of fresh music. Enjoy new music and deep cuts picked for you. Updates every Monday.",
+    "tracks": {
+        "href": "https://api.spotify.com/v1/playlists/37i9dQZEVXcBWKkqzRzenz/tracks?offset=0&limit=100",
+        "items": [
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "7IiLsCv7fvoqnZ95NPfRsw",
+                    "name": "Leave The Water Still",
+                    "uri": "spotify:track:7IiLsCv7fvoqnZ95NPfRsw"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "7eXIQjn66MGgQsPIwkooqR",
+                    "name": "We Don't Talk",
+                    "uri": "spotify:track:7eXIQjn66MGgQsPIwkooqR"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "60O5TDZ9AbLQf3m44Xzq9C",
+                    "name": "Shiloh",
+                    "uri": "spotify:track:60O5TDZ9AbLQf3m44Xzq9C"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "4FPTwDfFHaPgLP6ACaqgpr",
+                    "name": "Jakarta",
+                    "uri": "spotify:track:4FPTwDfFHaPgLP6ACaqgpr"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "5FK9E2XwYMx8Bhw3mQ7eGy",
+                    "name": "More",
+                    "uri": "spotify:track:5FK9E2XwYMx8Bhw3mQ7eGy"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "2WbFll5FxW0JEKIyijHNcb",
+                    "name": "Midnatt",
+                    "uri": "spotify:track:2WbFll5FxW0JEKIyijHNcb"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "6XY3Jr2kZDGVsMxsQn8uhw",
+                    "name": "Take It Home",
+                    "uri": "spotify:track:6XY3Jr2kZDGVsMxsQn8uhw"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "3gKhxGGUsproAWrYTFAyTX",
+                    "name": "Potions",
+                    "uri": "spotify:track:3gKhxGGUsproAWrYTFAyTX"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "0bk5Cch52RjA3SbWk5JsVu",
+                    "name": "UknoIknoUkno",
+                    "uri": "spotify:track:0bk5Cch52RjA3SbWk5JsVu"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "3LCXApiAIIvSzM03Aemhoi",
+                    "name": "Denise, Don’t Wanna See You Cry",
+                    "uri": "spotify:track:3LCXApiAIIvSzM03Aemhoi"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "2P15tzIexPvQsZCDZBaBzs",
+                    "name": "Feedback",
+                    "uri": "spotify:track:2P15tzIexPvQsZCDZBaBzs"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "3V3a55c5VdygC1lDOiOQbx",
+                    "name": "Asking Right",
+                    "uri": "spotify:track:3V3a55c5VdygC1lDOiOQbx"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "4cmc0AUXPBEpCY2IjhtVgg",
+                    "name": "Heavenly Father (Bon Iver)",
+                    "uri": "spotify:track:4cmc0AUXPBEpCY2IjhtVgg"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "0BpKvuvo3rBeypmTxsPShE",
+                    "name": "Ad Space",
+                    "uri": "spotify:track:0BpKvuvo3rBeypmTxsPShE"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "0X3QtyIJf8pC8wfbbRgNt5",
+                    "name": "Over Tage",
+                    "uri": "spotify:track:0X3QtyIJf8pC8wfbbRgNt5"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "1PiT4AuopBXRBvLIZk48BO",
+                    "name": "anotherlife",
+                    "uri": "spotify:track:1PiT4AuopBXRBvLIZk48BO"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "2KsuXBerIFkr9Ef8DJioTk",
+                    "name": "Thanks",
+                    "uri": "spotify:track:2KsuXBerIFkr9Ef8DJioTk"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "1RxTyElARYb3bzwnp51oNJ",
+                    "name": "Don't Call Her Over To You",
+                    "uri": "spotify:track:1RxTyElARYb3bzwnp51oNJ"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "5hgH4lqrKXSzauHoUiJV3q",
+                    "name": "River Day",
+                    "uri": "spotify:track:5hgH4lqrKXSzauHoUiJV3q"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "15oqkxMUZc8vrA7D2aV81v",
+                    "name": "Blue",
+                    "uri": "spotify:track:15oqkxMUZc8vrA7D2aV81v"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "7svBeBw3WFTv49xvaMeCm2",
+                    "name": "Make It Better",
+                    "uri": "spotify:track:7svBeBw3WFTv49xvaMeCm2"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "5s5s4tsN7u0oqQH5HaQYPA",
+                    "name": "Our Park By Night - Mixed",
+                    "uri": "spotify:track:5s5s4tsN7u0oqQH5HaQYPA"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "3CSgGrcAGMr0sfhNRQkhJk",
+                    "name": "Ignorancy",
+                    "uri": "spotify:track:3CSgGrcAGMr0sfhNRQkhJk"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "2hYZL212p2hBy5imoFq8FN",
+                    "name": "Godzilla",
+                    "uri": "spotify:track:2hYZL212p2hBy5imoFq8FN"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "37DpYxKAtHhvgYkMxruiPx",
+                    "name": "Good For Now (feat. Lucky Daye)",
+                    "uri": "spotify:track:37DpYxKAtHhvgYkMxruiPx"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "2KFmVlSxIzaGatl3lWTBie",
+                    "name": "sus (summer of innocence edit)",
+                    "uri": "spotify:track:2KFmVlSxIzaGatl3lWTBie"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "4TpieFNc0ietVb1ictUco1",
+                    "name": "Coastline",
+                    "uri": "spotify:track:4TpieFNc0ietVb1ictUco1"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "6o3SJNUuC9yEkR3IC15t2P",
+                    "name": "Space Intention",
+                    "uri": "spotify:track:6o3SJNUuC9yEkR3IC15t2P"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "3BGrvXWSNmnY9LAXxf5bqW",
+                    "name": "Long Summer Nights",
+                    "uri": "spotify:track:3BGrvXWSNmnY9LAXxf5bqW"
+                }
+            },
+            {
+                "added_at": "2023-09-24T23:00:00Z",
+                "track": {
+                    "id": "6bPgbVUEcKHd2Ar8ZoTZTZ",
+                    "name": "Det Bästa Vi Har",
+                    "uri": "spotify:track:6bPgbVUEcKHd2Ar8ZoTZTZ"
+                }
+            }
+        ],
+        "total": 30
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,8 +1,16 @@
 use crate::config::Config;
-use crate::spotify_error::Result;
+use crate::spotify_error::{Result, SpotifyError};
+use actix_http::encoding::Decoder;
+use actix_http::Payload;
 use async_trait::async_trait;
+use awc::error::SendRequestError;
+use awc::{ClientResponse, Connector};
+use base64::{engine::general_purpose, Engine as _};
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use serde::{Deserialize, Serialize};
 
+#[derive(Default)]
+pub struct AuthClient;
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct AuthResponse {
     pub code: Option<String>,
@@ -21,5 +29,57 @@ pub struct TokenResponse {
 
 #[async_trait(?Send)]
 pub trait FetchToken {
-    async fn fetch_token(&self, config: &Config, code: &AuthResponse) -> Result<TokenResponse>;
+    async fn fetch_token(
+        &self,
+        config: &Config,
+        auth_response: &AuthResponse,
+    ) -> Result<TokenResponse>;
+}
+
+#[async_trait(?Send)]
+impl FetchToken for AuthClient {
+    async fn fetch_token(
+        &self,
+        config: &Config,
+        auth_response: &AuthResponse,
+    ) -> Result<TokenResponse> {
+        let mut res = Self::get_token(auth_response, config).await?;
+        let json = res.json::<serde_json::Value>().await?;
+        if let Ok(auth_response) = serde_json::from_value::<TokenResponse>(json.clone()) {
+            return Ok(auth_response);
+        }
+        Err(SpotifyError::Unknown {
+            msg: json.to_string().into(),
+        })
+    }
+}
+
+impl AuthClient {
+    async fn get_token(
+        auth_response: &AuthResponse,
+        config: &Config,
+    ) -> Result<ClientResponse<Decoder<Payload>>, SendRequestError> {
+        let mut params = vec![
+            ("grant_type", "authorization_code"),
+            ("redirect_uri", &config.callback_url),
+        ];
+        if let Some(code) = &auth_response.code {
+            params.push(("code", code.as_str()));
+        }
+        let client_id = &config.spotify_client_id;
+        let client_secret = &config.spotify_client_secret;
+        let encoded =
+            general_purpose::STANDARD_NO_PAD.encode(client_id.to_owned() + ":" + client_secret);
+        let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
+        ssl_builder.set_verify(SslVerifyMode::NONE);
+        let client = awc::Client::builder()
+            .connector(Connector::new().openssl(ssl_builder.build()))
+            .finish();
+        client
+            .post(&config.auth_uri)
+            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
+            .insert_header(("Authorization", "Basic ".to_owned() + &encoded))
+            .send_form(&params)
+            .await
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,6 @@ pub trait ConfigProvider {
 pub struct DotEnvConfigProvider(Config);
 
 impl DotEnvConfigProvider {
-
     pub fn new() -> Self {
         use dotenv::dotenv;
         use std::env;
@@ -61,8 +60,8 @@ pub struct CmdConfigProvider(Config);
 
 impl CmdConfigProvider {
     pub fn new(args: Vec<String>, argv: HashMap<String, Vec<String>>) -> Self {
-        let db_name = args.iter().nth(1).expect("Missing config");
-        let db_password = args.iter().nth(2).expect("Missing config");
+        let db_name = args.get(1).expect("Missing config");
+        let db_password = args.get(2).expect("Missing config");
         let home_uri = argv.get("home_uri").expect("Missing config").to_vec();
         let client_id = argv.get("client_id").expect("Missing config").to_vec();
         let config = Config {
@@ -91,7 +90,7 @@ impl Default for CmdConfigProvider {
 pub struct EnvVarProvider(Config);
 
 impl EnvVarProvider {
-    pub fn new(args: HashMap<String, String>) -> Self {
+    pub fn new(_args: HashMap<String, String>) -> Self {
         let config = Config {
             ..Default::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 use actix_web::web::Redirect;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use discover_weekly::auth::{AuthResponse, FetchToken, TokenResponse};
-use discover_weekly::config::{
-    CmdConfigProvider, Config, ConfigProvider, DotEnvConfigProvider, EnvVarProvider,
-};
+use discover_weekly::auth::{AuthClient, AuthResponse, FetchToken};
+use discover_weekly::config::{ConfigProvider, DotEnvConfigProvider};
 use discover_weekly::spotify::SpotifyClient;
-use discover_weekly::spotify_error::Result;
 use discover_weekly::store::Store;
 use log::info;
 use std::env;
@@ -19,37 +16,29 @@ async fn callback(data: web::Data<AppState>, response: web::Query<AuthResponse>)
     let auth_response = response.into_inner();
     let app_data = data.into_inner();
     let config_provider = &app_data.config_provider;
-    let app_config = &config_provider.get_config();
-    match auth_response.code.clone() {
-        Some(_code) => {
-            // User approved request,
-            info!("Code successfully fetched");
-            let client = Box::new(SpotifyClient::new());
-            let response = get_access_token(&auth_response, client.clone(), app_config).await;
-            match response {
-                Ok(token_response) => {
-                    let store = Store::open(app_config).await;
-                    let _ = store.unwrap().store_access_tokens(&token_response).await;
-                    let playlist = client
-                        .get_discovery_weekly_playlist(app_config, &token_response.access_token)
-                        .await;
-                    HttpResponse::Ok().body(serde_json::to_string(&playlist.unwrap()).unwrap())
-                }
-                Err(err) => HttpResponse::Ok().body(err.to_string()),
+    let app_config = config_provider.get_config();
+    if let Some(_code) = &auth_response.code {
+        // User approved request,
+        info!("Code successfully fetched");
+        let auth_client = AuthClient;
+        let auth_info = auth_client.fetch_token(app_config, &auth_response).await;
+        match auth_info {
+            Ok(token_response) => {
+                let spotify_client = SpotifyClient::new(token_response.clone());
+                let store = Store::open(app_config).await;
+                let _ = store.unwrap().store_access_tokens(&token_response).await;
+                let playlist = spotify_client
+                    .get_discovery_weekly_playlist(app_config)
+                    .await;
+                return HttpResponse::Ok().body(serde_json::to_string(&playlist.unwrap()).unwrap());
             }
-        }
-        None => {
-            // Error occurred or user denied request
-            let error = auth_response.error.clone().unwrap_or_default();
-            info!(
-                "Request unsuccessful. error: {}, state: {}",
-                error,
-                auth_response.state.clone().unwrap_or_default()
-            );
-            let reply = serde_json::to_string(&auth_response);
-            HttpResponse::Ok().body(reply.expect("Error unwrapping error"))
+            Err(err) => return HttpResponse::Ok().body(err.to_string()),
         }
     }
+    // Error occurred or user denied request
+    let reply = serde_json::to_string(&auth_response).unwrap();
+    info!("{}", &reply);
+    HttpResponse::Ok().body(reply)
 }
 #[get("/")]
 async fn index(data: web::Data<AppState>) -> impl Responder {
@@ -66,10 +55,6 @@ async fn main() -> std::io::Result<()> {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
     assert!(args.len() > 2, "cargo run -- <HOST> <PORT>");
-    let (args1, argv) = argmap::parse(env::args());
-    let _env_config_provider = EnvVarProvider::new(env::vars().collect());
-    let _cmd_config_provider = CmdConfigProvider::new(args1, argv);
-    test_method(_cmd_config_provider);
     let bind_address: &str = &args[1];
     let bind_port: u16 = args[2].parse().unwrap();
     info!("Open: {}:{}", bind_address, bind_port);
@@ -86,24 +71,12 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
-pub async fn get_access_token<'a>(
-    code: &'a AuthResponse,
-    client: Box<dyn FetchToken>,
-    config: &Config,
-) -> Result<TokenResponse> {
-    let response = client.fetch_token(config, code).await?;
-    Ok(response)
-}
-fn test_method<T>(config_provider: T)
-    where T: ConfigProvider
-{
-    let db_name = config_provider.get_config().db_name;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use discover_weekly::spotify_error::Result;
+    use discover_weekly::{auth::TokenResponse, config::Config};
     const TEST_RESPONSE: &str = r#"
         {
             "access_token": "BQDmaWDt6ToQqjXdKS9yx7zm9qk9r5Mb0",
@@ -119,7 +92,7 @@ mod tests {
         async fn fetch_token(
             &self,
             _config: &Config,
-            _code: &AuthResponse,
+            _auth_response: &AuthResponse,
         ) -> Result<TokenResponse> {
             let response: TokenResponse = serde_json::from_str(&TEST_RESPONSE).unwrap();
             Ok(response)
@@ -141,12 +114,11 @@ mod tests {
 
     #[test]
     fn test_access_token() {
-        let client = Box::new(MockClient {});
-        let test_response = async_std::task::block_on(get_access_token(
-            &AuthResponse::default(),
-            client,
-            MockConfigProvider::default().get_config(),
-        ));
+        let client = MockClient {};
+        let auth_response = AuthResponse::default();
+        let config_provider = MockConfigProvider::default();
+        let config = config_provider.get_config();
+        let test_response = async_std::task::block_on(client.fetch_token(config, &auth_response));
         assert!(test_response.is_ok());
         let token = test_response.unwrap().access_token;
         assert!(!token.is_empty());

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -1,12 +1,7 @@
-use crate::auth::{AuthResponse, FetchToken, TokenResponse};
+use crate::auth::TokenResponse;
 use crate::config::Config;
 use crate::spotify_error::{Result, SpotifyError};
-use actix_http::encoding::Decoder;
-use actix_http::Payload;
-use async_trait::async_trait;
-use awc::error::SendRequestError;
-use awc::{ClientResponse, Connector};
-use base64::{engine::general_purpose, Engine as _};
+use awc::Connector;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use serde::{Deserialize, Serialize};
 
@@ -39,102 +34,48 @@ pub struct Playlist {
 }
 
 #[derive(Clone)]
-pub struct SpotifyClient;
-
-#[async_trait(?Send)]
-impl FetchToken for SpotifyClient {
-    async fn fetch_token(&self, config: &Config, code: &AuthResponse) -> Result<TokenResponse> {
-        let mut res = Self::get_token(code, config).await?;
-        let json = res.json::<serde_json::Value>().await?;
-        if let Ok(auth_response) = serde_json::from_value::<TokenResponse>(json.clone()) {
-            return Ok(auth_response);
-        }
-        Err(SpotifyError::Unknown {
-            msg: json.to_string().into(),
-        })
-    }
-}
-
-impl Default for SpotifyClient {
-    fn default() -> Self {
-        Self::new()
-    }
+pub struct SpotifyClient {
+    auth_info: TokenResponse,
 }
 
 impl SpotifyClient {
-    pub fn new() -> SpotifyClient {
-        SpotifyClient {}
+    pub fn new(token_response: TokenResponse) -> SpotifyClient {
+        SpotifyClient {
+            auth_info: token_response,
+        }
     }
 
-    async fn get_token(
-        code: &AuthResponse,
-        config: &Config,
-    ) -> Result<ClientResponse<Decoder<Payload>>, SendRequestError> {
-        let params = [
-            ("grant_type", "authorization_code"),
-            ("code", &code.code.clone().unwrap_or_default()),
-            ("redirect_uri", &config.callback_url),
-        ];
-        let client_id = &config.spotify_client_id.to_string();
-        let client_secret = &config.spotify_client_secret;
-        let encoded =
-            general_purpose::STANDARD_NO_PAD.encode(client_id.to_string() + ":" + client_secret);
+    async fn get<T>(&self, uri: &str) -> Result<T>
+    where
+        T: for<'de> serde::Deserialize<'de>,
+    {
         let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
         ssl_builder.set_verify(SslVerifyMode::NONE);
         let client = awc::Client::builder()
             .connector(Connector::new().openssl(ssl_builder.build()))
             .finish();
-        client
-            .post(&config.auth_uri)
-            .insert_header(("Content-Type", "application/x-www-form-urlencoded"))
-            .insert_header(("Authorization", "Basic ".to_owned() + &encoded))
-            .send_form(&params)
-            .await
+        let mut response = client
+            .get(uri)
+            .insert_header((
+                "Authorization",
+                "Bearer ".to_owned() + &self.auth_info.access_token,
+            ))
+            .send()
+            .await?;
+        let json = response.json::<serde_json::Value>().await?;
+        if let Ok(result) = serde_json::from_value::<T>(json) {
+            return Ok(result);
+        }
+        Err(SpotifyError::Unknown { msg: None })
     }
-    pub async fn get_discovery_weekly_playlist(
-        self,
-        config: &Config,
-        bearer: &str,
-    ) -> Result<Playlist> {
+    pub async fn get_discovery_weekly_playlist(&self, config: &Config) -> Result<Playlist> {
         let base_url = &config.base_url;
         let uri = base_url.to_owned() + "/playlists/" + &config.discover_playlist;
-        let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
-        ssl_builder.set_verify(SslVerifyMode::NONE);
-        let client = awc::Client::builder()
-            .connector(Connector::new().openssl(ssl_builder.build()))
-            .finish();
-        let mut response = client
-            .get(uri)
-            .insert_header(("Authorization", "Bearer ".to_owned() + bearer))
-            .send()
-            .await?;
-        let json = response.json::<serde_json::Value>().await?;
-        if let Ok(playlist) = serde_json::from_value::<Playlist>(json) {
-            return Ok(playlist);
-        }
-        Err(SpotifyError::CantFetchPlaylist(
-            "Error fetching playlist".into(),
-        ))
+        self.get::<Playlist>(&uri).await
     }
-    pub async fn get_or_create_archive_playlist(self, config: &Config, bearer: &str) -> Result<Playlist> {
+    pub async fn get_or_create_archive_playlist(&self, config: &Config) -> Result<Playlist> {
         let base_url = &config.base_url;
         let uri = base_url.to_owned() + "/me/playlists?limit=50";
-        let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
-        ssl_builder.set_verify(SslVerifyMode::NONE);
-        let client = awc::Client::builder()
-            .connector(Connector::new().openssl(ssl_builder.build()))
-            .finish();
-        let mut response = client
-            .get(uri)
-            .insert_header(("Authorization", "Bearer ".to_owned() + bearer))
-            .send()
-            .await?;
-        let json = response.json::<serde_json::Value>().await?;
-        if let Ok(playlist) = serde_json::from_value::<Playlist>(json) {
-            return Ok(playlist);
-        }
-        Err(SpotifyError::CantFetchPlaylist(
-            "Error fetching playlist".into(),
-        ))
+        self.get::<Playlist>(&uri).await
     }
 }


### PR DESCRIPTION
- Introduce a new `AuthClient` to encapsulate all the Auth related logic
- Make `SpotifyClient` hold access tokens to avoid unnecessary method parameters
- Refactor out the GET method call to another method to remove duplicated code.
